### PR TITLE
Write valid pieces received directly to file

### DIFF
--- a/torrentfile/torrentfile.go
+++ b/torrentfile/torrentfile.go
@@ -58,20 +58,11 @@ func (t *TorrentFile) DownloadToFile(path string) error {
 		Length:      t.Length,
 		Name:        t.Name,
 	}
-	buf, err := torrent.Download()
+	err = torrent.Download(path)
 	if err != nil {
 		return err
 	}
 
-	outFile, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer outFile.Close()
-	_, err = outFile.Write(buf)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
Keeping all pieces in a buffer may lead to memory issues for larger files, so the obvious fix is just reading the pieces into the file. This may 

Files changed:
`p2p.go`
- `Download` now takes in a filepath, and returns nil upon success
- when a worker submits work to the results channel, the offset is calculated via piece index and written to the file

`torrentfile.go`
- `DownloadToFile` just calls download, so it is actually not that necessary anymore