### PR TITLE
Directly return err instead of nil

### DIFF
--- a/torrentfile/torrentfile.go
+++ b/torrentfile/torrentfile.go
@@ -69,10 +69,7 @@ func (t *TorrentFile) DownloadToFile(path string) error {
 	}
 	defer outFile.Close()
 	_, err = outFile.Write(buf)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Open parses a torrent file


### PR DESCRIPTION
(Hi, this is my first pull request ever made ahahah). I notice that in the download function in the torrentfile the final error handling can be semplified to be directly returned instead of checking if != nil or returning nil